### PR TITLE
move the ApplicationService to /Api 

### DIFF
--- a/lib/CleanArch/Abstractions/IApplicationApi.cs
+++ b/lib/CleanArch/Abstractions/IApplicationApi.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 
 namespace CleanArch.Abstractions;
 
-public interface IApplicationService
+public interface IApplicationApi
 {
     Task<TUseCaseResult> Handle<TUseCaseResult>(IUseCase<TUseCaseResult> useCase, CancellationToken stoppingToken = default);
     IAsyncEnumerable<TUseCaseResult> Stream<TUseCaseResult>(IUseCase<TUseCaseResult> useCase, CancellationToken stoppingToken = default);

--- a/lib/CleanArch/Api/AppApiHomebrew.cs
+++ b/lib/CleanArch/Api/AppApiHomebrew.cs
@@ -9,11 +9,11 @@ namespace CleanArch.Abstractions;
 // app service which just relies on DI -
 // does NOT take dep on IServiceProvider (service-locator anti-pattern )
 // does NOT use mediatR (for scenarios where using 3rd party libs are not allowed)
-public partial class AppServiceHomebrew : IApplicationService
+public partial class AppApiHomebrew : IApplicationApi
 {
     private readonly IEnumerable<IUseCaseHandler> _allUseCaseHandlers;
 
-    public AppServiceHomebrew(IEnumerable<IUseCaseHandler> allUseCaseHandlers)
+    public AppApiHomebrew(IEnumerable<IUseCaseHandler> allUseCaseHandlers)
     {
         _allUseCaseHandlers = allUseCaseHandlers;
     }

--- a/src/Api/Program.cs
+++ b/src/Api/Program.cs
@@ -7,7 +7,7 @@ var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddGrpc();
 builder.Services.AddGrpcReflection();
-builder.Services.AddScoped<IApplicationService, AppServiceHomebrew>();
+builder.Services.AddScoped<IApplicationApi, AppApiHomebrew>();
 builder.Services.AddScoped<IUseCaseHandler, PingUseCaseHandler>();
 builder.Services.AddScoped<IUseCaseHandler, CountdownUseCaseHandler>();
 

--- a/src/Api/Protos/doomsday.proto
+++ b/src/Api/Protos/doomsday.proto
@@ -2,10 +2,14 @@ syntax = "proto3";
 
 package doomsday; 
 /* This becomes the c# namespace (and is pascal-cased when generated) 
-   if the 'option csharp_namespace = xxx' option is ommitted. */
+   if the 'option csharp_namespace = xxx' option is ommitted. 
+   
+   Note also, this becomes part of the ROUTE/URL = grpc://{doomsday}.{DoomsdayClock}/{endpointName}
+   */
 
 import "google/protobuf/timestamp.proto";
 
+/* the service name becomes part of the ROUTE/URL also (see above) */
 service DoomsdayClock {
     rpc GetCountdown(GetCountdownRequest) returns (stream GetCountdownResponse);
     rpc Ping(PingRequest) returns (PingResponse);

--- a/src/Api/Services/DoomsdayClockService.cs
+++ b/src/Api/Services/DoomsdayClockService.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Threading;
 using System.Threading.Tasks;
 using CleanArch.Abstractions;
 using Core.Application.Contracts.UseCases;
@@ -14,13 +12,11 @@ namespace Api.Services;
 /// </summary>
 public class DoomsdayClockService : Doomsday.DoomsdayClock.DoomsdayClockBase
 {
-    private readonly PeriodicTimer _timer;
-    private readonly IApplicationService _appService;
+    private readonly IApplicationApi _appApi;
 
-    public DoomsdayClockService(IApplicationService appService)
+    public DoomsdayClockService(IApplicationApi appApi)
     {
-        _appService = appService;
-        _timer = new PeriodicTimer(TimeSpan.FromSeconds(1));
+        _appApi = appApi;
     }
 
     public override async Task GetCountdown(GetCountdownRequest request, IServerStreamWriter<GetCountdownResponse> responseStream, ServerCallContext context)
@@ -29,7 +25,7 @@ public class DoomsdayClockService : Doomsday.DoomsdayClock.DoomsdayClockBase
         var useCase = new Countdown.UseCase();
 
         // execute app  (handle usecase) & get response
-        await foreach (var time in _appService.Stream(useCase, context.CancellationToken))
+        await foreach (var time in _appApi.Stream(useCase, context.CancellationToken))
         {
             //map app response to public contract (use AutoMapper ACL)
             var response = new GetCountdownResponse
@@ -47,7 +43,7 @@ public class DoomsdayClockService : Doomsday.DoomsdayClock.DoomsdayClockBase
         var useCase = new Ping.UseCase();
 
         // execute app  (handle usecase) & get response
-        var useCaseResult = await _appService.Handle(useCase, context.CancellationToken);
+        var useCaseResult = await _appApi.Handle(useCase, context.CancellationToken);
 
         //map app response to public contract (use AutoMapper ACL)
         var response = new PingResponse


### PR DESCRIPTION
thought as to not conflate Application Services & Infrastructure Services using within Application, that id move the ApplicationService to /Api (Application's API - to the outside consumer)